### PR TITLE
Fix GitHub issues link

### DIFF
--- a/app/fire-enrich/README.md
+++ b/app/fire-enrich/README.md
@@ -267,6 +267,6 @@ If you prefer not to use environment variables, Fire Enrich supports entering AP
 
 For issues or questions:
 - Use this template: [https://github.com/mendableai/fire-enrich](https://github.com/mendableai/fire-enrich)
-- Check the [GitHub Issues](https://github.com/your-repo/issues)
+- Check the [GitHub Issues](https://github.com/mendableai/fire-enrich/issues)
 - Review error messages and logs
 - Ensure API keys have sufficient credits


### PR DESCRIPTION
## Summary
- update placeholder link to point at real GitHub Issues in support docs

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68509c901cc483219f88166767ceb878