### PR TITLE
Fix broken link for Vercel deploy button

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Turn a simple list of emails into a rich dataset with company profiles, funding 
 - **OpenAI**: Intelligent data extraction and synthesis
 - **Next.js 15**: Modern React framework with App Router
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fmendableai%2Ffire-enrich-standalone&env=FIRECRAWL_API_KEY,OPENAI_API_KEY&envDescription=API%20keys%20required%20for%20Fire%20Enrich&envLink=https%3A%2F%2Fgithub.com%2Fmendableai%2Ffire-enrich-standalone%23required-api-keys)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fmendableai%2Ffire-enrich&env=FIRECRAWL_API_KEY,OPENAI_API_KEY&envDescription=API%20keys%20required%20for%20Fire%20Enrich&envLink=https%3A%2F%2Fgithub.com%2Fmendableai%2Ffire-enrich%23required-api-keys)
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- update the README to use the correct repo in the Deploy with Vercel link

## Testing
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6852049926088321bafca04ce234797a